### PR TITLE
infra: Tollgate 2 — workflow parity with Unfocused

### DIFF
--- a/.github/workflows/auto-promote-ready.yml
+++ b/.github/workflows/auto-promote-ready.yml
@@ -2,12 +2,12 @@ name: Auto-Promote Ready Issues
 
 # Two triggers:
 # 1. Event-driven: fires when any issue is closed
-# 2. Cron fallback: every 30 minutes in case events are missed
+# 2. Cron fallback: every 6 hours (conserves GraphQL budget)
 on:
   issues:
     types: [closed]
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch: {} # Manual trigger for testing
 
 jobs:

--- a/.github/workflows/sync-labels-to-board.yml
+++ b/.github/workflows/sync-labels-to-board.yml
@@ -1,0 +1,149 @@
+name: Sync Labels to Project Board
+
+# Maps board: and priority: labels → Project V2 board fields via GraphQL.
+# Agents set labels via REST (zero GraphQL cost from agent side).
+# This Action translates those labels into board field updates.
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: >-
+      startsWith(github.event.label.name, 'board:') ||
+      startsWith(github.event.label.name, 'priority:')
+    steps:
+      - name: Sync label to project board
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_PAT }}
+          script: |
+            // ── Project field IDs (Field_Compass project #3) ────────
+            const PROJECT_ID = 'PVT_kwHODGcOBc4BOJgD';
+
+            const STATUS_FIELD_ID = 'PVTSSF_lAHODGcOBc4BOJgDzg872EE';
+            const STATUS_OPTIONS = {
+              'board:backlog':     '3dcf161f',  // Backlog
+              'board:todo':        '40e1ce62',  // Todo
+              'board:ready':       'c9d9a904',  // Ready
+              'board:in-progress': 'ed9b3596',  // In Progress
+              'board:testing':     'f24c3b98',  // Testing
+              'board:on-hold':     'b8fb7ef8',  // On Hold
+              'board:done':        '0a973c3f',  // Done
+            };
+
+            const PRIORITY_FIELD_ID = 'PVTSSF_lAHODGcOBc4BOJgDzg872kc';
+            const PRIORITY_OPTIONS = {
+              'priority:P0': 'c5d8bb6a',  // P0 - Critical
+              'priority:P1': '6107e8d5',  // P1 - High
+              'priority:P2': '464bc5bf',  // P2 - Medium
+              'priority:P3': '4e96770a',  // P3 - Low/Cosmetic
+            };
+
+            // ── Determine what triggered us ─────────────────────────
+            const triggerLabel = context.payload.label.name;
+            const issueNumber = context.payload.issue.number;
+            const issueNodeId = context.payload.issue.node_id;
+            const issueLabels = context.payload.issue.labels.map(l => l.name);
+
+            core.info(`Label "${triggerLabel}" added to #${issueNumber}`);
+
+            let triggerPrefix;
+            if (triggerLabel.startsWith('board:'))    triggerPrefix = 'board:';
+            else if (triggerLabel.startsWith('priority:')) triggerPrefix = 'priority:';
+            else {
+              core.info('Not a board/priority label — skipping');
+              return;
+            }
+
+            // ── Mutual exclusion: remove other labels in the same group ─
+            const conflicting = issueLabels.filter(
+              l => l.startsWith(triggerPrefix) && l !== triggerLabel
+            );
+            for (const oldLabel of conflicting) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: oldLabel,
+                });
+                core.info(`Removed conflicting label: ${oldLabel}`);
+              } catch (e) {
+                core.warning(`Could not remove label "${oldLabel}": ${e.message}`);
+              }
+            }
+
+            // ── Add issue to project board (idempotent) ─────────────
+            const addMutation = `
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: {
+                  projectId: $projectId
+                  contentId: $contentId
+                }) {
+                  item { id }
+                }
+              }
+            `;
+
+            let itemId;
+            try {
+              const addResult = await github.graphql(addMutation, {
+                projectId: PROJECT_ID,
+                contentId: issueNodeId,
+              });
+              itemId = addResult.addProjectV2ItemById.item.id;
+              core.info(`Project item: ${itemId}`);
+            } catch (e) {
+              core.setFailed(`Failed to add #${issueNumber} to project: ${e.message}`);
+              return;
+            }
+
+            // ── Update field mutation ───────────────────────────────
+            const updateMutation = `
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $optionId }
+                }) {
+                  projectV2Item { id }
+                }
+              }
+            `;
+
+            // ── Sync ALL board/priority labels ──────────────────────
+            const boardLabel = issueLabels.find(l => l.startsWith('board:') && STATUS_OPTIONS[l]);
+            const priorityLabel = issueLabels.find(l => l.startsWith('priority:') && PRIORITY_OPTIONS[l]);
+
+            if (boardLabel) {
+              try {
+                await github.graphql(updateMutation, {
+                  projectId: PROJECT_ID,
+                  itemId: itemId,
+                  fieldId: STATUS_FIELD_ID,
+                  optionId: STATUS_OPTIONS[boardLabel],
+                });
+                core.info(`✅ Status → ${boardLabel}`);
+              } catch (e) {
+                core.setFailed(`Failed to set status: ${e.message}`);
+              }
+            }
+
+            if (priorityLabel) {
+              try {
+                await github.graphql(updateMutation, {
+                  projectId: PROJECT_ID,
+                  itemId: itemId,
+                  fieldId: PRIORITY_FIELD_ID,
+                  optionId: PRIORITY_OPTIONS[priorityLabel],
+                });
+                core.info(`✅ Priority → ${priorityLabel}`);
+              } catch (e) {
+                core.setFailed(`Failed to set priority: ${e.message}`);
+              }
+            }
+
+            core.info(`Done syncing #${issueNumber}`);

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,99 @@
+# =============================================================================
+# Version Bump — increment version tag on every merge to main
+# =============================================================================
+# Reads the commit prefix (feat/fix/chore/etc.) and bumps semver accordingly.
+# Tag-only (no version file to update).
+#
+# Safety:
+#   - Concurrency group queues concurrent runs (no cancel)
+#   - ref:main + fetch-tags + pull --rebase ensures latest state
+#   - Tag-exists check prevents duplicate tag errors
+#   - actor guard prevents infinite loop from its own push
+# =============================================================================
+
+name: Version Bump
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: auto-version-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    if: >-
+      github.repository == 'Strycher/Field_Compass'
+      && github.actor != 'github-actions[bot]'
+      && !startsWith(github.event.head_commit.message, 'chore: bump version')
+      && !startsWith(github.event.head_commit.message, 'bd:')
+      && !startsWith(github.event.head_commit.message, 'Merge')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Pull latest main (in case queued behind another bump)
+        run: git pull origin main --rebase
+
+      - name: Get latest tag
+        id: current
+        run: |
+          TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Current tag: $TAG"
+
+      - name: Determine bump type
+        id: bump
+        run: |
+          MSG=$(git log -1 --pretty=%s)
+          echo "Commit message: $MSG"
+          PREFIX=$(echo "$MSG" | grep -oP '^\w+' | head -1)
+
+          if [ "$PREFIX" = "feat" ]; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+            echo "Bump type: MINOR (new feature)"
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+            echo "Bump type: PATCH ($PREFIX)"
+          fi
+
+      - name: Calculate new version
+        id: new
+        run: |
+          TAG="${{ steps.current.outputs.tag }}"
+          VERSION="${TAG#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          case "${{ steps.bump.outputs.type }}" in
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            *)     PATCH=$((PATCH + 1)) ;;
+          esac
+
+          NEW="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "tag=$NEW" >> "$GITHUB_OUTPUT"
+          echo "New version: $NEW"
+
+      - name: Tag and push
+        run: |
+          NEW="${{ steps.new.outputs.tag }}"
+
+          if git rev-parse "$NEW" >/dev/null 2>&1; then
+            echo "⏭️ Tag $NEW already exists — another run handled this bump"
+            exit 0
+          fi
+
+          git tag -a "$NEW" -m "$NEW"
+          git push origin "$NEW"
+          echo "✅ Version bumped: ${{ steps.current.outputs.tag }} → $NEW"


### PR DESCRIPTION
## Summary
- **Add** `version-bump.yml` — semantic versioning with race condition safety (concurrency group, `ref:main`, `fetch-tags`, tag-exists check)
- **Add** `sync-labels-to-board.yml` — maps `board:*` / `priority:*` labels to Project V2 board fields via GraphQL. Agents use `gh issue edit --add-label` (REST, zero GraphQL cost).
- **Fix** `auto-promote-ready.yml` — reduce cron from `*/30` (48 runs/day) to `0 */6` (4 runs/day) to conserve GraphQL budget

## Test plan
- [ ] Merge this PR — version-bump should create a tag
- [ ] Add `board:ready` label to any issue — should sync to project board
- [ ] Verify auto-promote runs every 6h instead of every 30min

🤖 Generated with [Claude Code](https://claude.com/claude-code)