### PR TITLE
docs: CLAUDE.md parity + REST-only auto-promote

### DIFF
--- a/.github/workflows/auto-promote-ready.yml
+++ b/.github/workflows/auto-promote-ready.yml
@@ -1,13 +1,17 @@
 name: Auto-Promote Ready Issues
 
-# Two triggers:
-# 1. Event-driven: fires when any issue is closed
-# 2. Cron fallback: every 6 hours (conserves GraphQL budget)
+# Fires when a dependency closes. Checks if downstream issues
+# have all deps resolved — if so, promotes Todo → Ready via label.
+#
+# ZERO GraphQL cost from this Action. Uses REST only.
+# The sync-labels-to-board Action handles the board field update.
+#
+# Cron fallback catches edge cases (manual closes, missed events).
 on:
   issues:
     types: [closed]
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '0 */4 * * *'
   workflow_dispatch: {} # Manual trigger for testing
 
 jobs:
@@ -17,66 +21,13 @@ jobs:
       - name: Promote unblocked issues to Ready
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PROJECT_PAT }}
+          # Default GITHUB_TOKEN is sufficient — REST only, no GraphQL.
           script: |
-            const PROJECT_NUMBER = 3;
             const OWNER = 'Strycher';
             const REPO = 'Field_Compass';
 
-            // ── Step 1: Get project metadata (field IDs, option IDs) ──
-            const projectQuery = `
-              query($owner: String!, $number: Int!) {
-                user(login: $owner) {
-                  projectV2(number: $number) {
-                    id
-                    fields(first: 20) {
-                      nodes {
-                        ... on ProjectV2SingleSelectField {
-                          id
-                          name
-                          options { id name }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            `;
-
-            const projectResult = await github.graphql(projectQuery, {
-              owner: OWNER,
-              number: PROJECT_NUMBER,
-            });
-
-            const project = projectResult.user.projectV2;
-            const projectId = project.id;
-
-            // Find Status field and its option IDs
-            const statusField = project.fields.nodes.find(
-              f => f.name === 'Status'
-            );
-            if (!statusField) {
-              core.setFailed('Could not find Status field on project');
-              return;
-            }
-
-            const todoOptionId = statusField.options.find(
-              o => o.name === 'Todo'
-            )?.id;
-            const readyOptionId = statusField.options.find(
-              o => o.name === 'Ready'
-            )?.id;
-
-            if (!todoOptionId || !readyOptionId) {
-              core.setFailed('Could not find Todo or Ready options');
-              return;
-            }
-
-            core.info(`Project: ${projectId}`);
-            core.info(`Status field: ${statusField.id}`);
-            core.info(`Todo: ${todoOptionId}, Ready: ${readyOptionId}`);
-
-            // ── Step 2: Get all open issues in the repo ──
+            // ── Step 1: Get all issues (open + closed for dep resolution) ──
+            // Uses REST pagination — zero GraphQL cost.
             let allIssues = [];
             let page = 1;
             while (true) {
@@ -87,20 +38,25 @@ jobs:
                 per_page: 100,
                 page: page,
               });
-              allIssues = allIssues.concat(batch.data);
+              // Filter out pull requests (GitHub REST returns PRs in issues endpoint)
+              const issuesOnly = batch.data.filter(i => !i.pull_request);
+              allIssues = allIssues.concat(issuesOnly);
               if (batch.data.length < 100) break;
               page++;
             }
 
-            // Build lookup: issue number → state
-            const issueState = {};
+            // Build lookup: issue number → { state, labels }
+            const issueMap = {};
             for (const issue of allIssues) {
-              issueState[issue.number] = issue.state; // 'open' or 'closed'
+              issueMap[issue.number] = {
+                state: issue.state,
+                labels: issue.labels.map(l => l.name),
+              };
             }
 
-            core.info(`Loaded ${allIssues.length} issues total`);
+            core.info(`Loaded ${allIssues.length} issues`);
 
-            // ── Step 3: Find open issues with depends-on tags ──
+            // ── Step 2: Find open Todo issues with all deps resolved ──
             const dependsOnRegex = /<!--\s*depends-on:\s*(#\d+(?:\s*,\s*#\d+)*)\s*-->/g;
             const promotionCandidates = [];
 
@@ -108,10 +64,14 @@ jobs:
               if (issue.state !== 'open') continue;
               if (!issue.body) continue;
 
+              // Must currently be in Todo (has board:todo label)
+              const labels = issue.labels.map(l => l.name);
+              if (!labels.includes('board:todo')) continue;
+
+              // Parse depends-on tags
               const matches = [...issue.body.matchAll(dependsOnRegex)];
               if (matches.length === 0) continue;
 
-              // Parse all dependency numbers
               const deps = [];
               for (const match of matches) {
                 const numMatches = match[1].matchAll(/#(\d+)/g);
@@ -124,7 +84,7 @@ jobs:
 
               // Check if ALL dependencies are closed
               const allDepsClosed = deps.every(
-                depNum => issueState[depNum] === 'closed'
+                depNum => issueMap[depNum]?.state === 'closed'
               );
 
               if (allDepsClosed) {
@@ -136,120 +96,45 @@ jobs:
               }
             }
 
-            core.info(`Found ${promotionCandidates.length} issues ready to promote`);
+            core.info(`Found ${promotionCandidates.length} issues to promote`);
 
             if (promotionCandidates.length === 0) {
               core.info('No issues to promote. Done.');
               return;
             }
 
-            // ── Step 4: Get project items to find their IDs and current status ──
-            let projectItems = [];
-            let hasNextPage = true;
-            let cursor = null;
-
-            while (hasNextPage) {
-              const itemsQuery = `
-                query($projectId: ID!, $cursor: String) {
-                  node(id: $projectId) {
-                    ... on ProjectV2 {
-                      items(first: 100, after: $cursor) {
-                        pageInfo { hasNextPage endCursor }
-                        nodes {
-                          id
-                          content {
-                            ... on Issue { number }
-                          }
-                          fieldValues(first: 10) {
-                            nodes {
-                              ... on ProjectV2ItemFieldSingleSelectValue {
-                                field { ... on ProjectV2SingleSelectField { name } }
-                                optionId
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              `;
-
-              const itemsResult = await github.graphql(itemsQuery, {
-                projectId: projectId,
-                cursor: cursor,
-              });
-
-              const items = itemsResult.node.items;
-              projectItems = projectItems.concat(items.nodes);
-              hasNextPage = items.pageInfo.hasNextPage;
-              cursor = items.pageInfo.endCursor;
-            }
-
-            core.info(`Loaded ${projectItems.length} project items`);
-
-            // ── Step 5: Promote eligible issues from Todo → Ready ──
+            // ── Step 3: Promote by adding board:ready label (REST) ──
+            // The sync-labels-to-board Action handles the board field update.
+            // Label mutual exclusion (removing board:todo) is also handled there.
             let promoted = 0;
 
             for (const candidate of promotionCandidates) {
-              // Find this issue's project item
-              const projectItem = projectItems.find(
-                item => item.content?.number === candidate.number
-              );
+              try {
+                // Add board:ready label — triggers sync-labels-to-board Action
+                await github.rest.issues.addLabels({
+                  owner: OWNER,
+                  repo: REPO,
+                  issue_number: candidate.number,
+                  labels: ['board:ready'],
+                });
 
-              if (!projectItem) {
-                core.warning(
-                  `#${candidate.number} not found on project board — skipping`
-                );
-                continue;
-              }
+                // Audit trail comment
+                await github.rest.issues.createComment({
+                  owner: OWNER,
+                  repo: REPO,
+                  issue_number: candidate.number,
+                  body: `🤖 **Auto-promoted to Ready** — all dependencies resolved (${candidate.deps.map(d => '#' + d).join(', ')} closed).`,
+                });
 
-              // Check current status — only promote from Todo
-              const currentStatus = projectItem.fieldValues.nodes.find(
-                fv => fv.field?.name === 'Status'
-              );
-
-              if (currentStatus?.optionId !== todoOptionId) {
                 core.info(
-                  `#${candidate.number} is not in Todo — skipping ` +
-                  `(current: ${currentStatus?.optionId || 'none'})`
+                  `✅ Promoted #${candidate.number} (${candidate.title}) to Ready`
                 );
-                continue;
+                promoted++;
+              } catch (e) {
+                core.warning(
+                  `Failed to promote #${candidate.number}: ${e.message}`
+                );
               }
-
-              // Move to Ready!
-              const mutation = `
-                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-                  updateProjectV2ItemFieldValue(input: {
-                    projectId: $projectId
-                    itemId: $itemId
-                    fieldId: $fieldId
-                    value: { singleSelectOptionId: $optionId }
-                  }) {
-                    projectV2Item { id }
-                  }
-                }
-              `;
-
-              await github.graphql(mutation, {
-                projectId: projectId,
-                itemId: projectItem.id,
-                fieldId: statusField.id,
-                optionId: readyOptionId,
-              });
-
-              // Add a comment so there's a visible audit trail
-              await github.rest.issues.createComment({
-                owner: OWNER,
-                repo: REPO,
-                issue_number: candidate.number,
-                body: `🤖 **Auto-promoted to Ready** — all dependencies resolved (${candidate.deps.map(d => '#' + d).join(', ')} closed).`,
-              });
-
-              core.info(
-                `✅ Promoted #${candidate.number} (${candidate.title}) to Ready`
-              );
-              promoted++;
             }
 
             core.info(`\nDone! Promoted ${promoted} issues to Ready.`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,27 +206,28 @@ At session start, after registering with Agent Mail, check `bd list --status=in_
 
 This project has a single ~8,000-line source file (`Field_Compass.ino`). Parallel agents virtually guarantee conflicts. This is not like a multi-file web project — serialize by default.
 
-### Infrastructure Health Check (MANDATORY)
+### Dolt Server (Hetzner Docker)
 
-At the start of every session, verify all infrastructure is operational before doing any work:
+| Field        | Value                                                     |
+|--------------|-----------------------------------------------------------|
+| Container    | `dolt-beads` on Hetzner (`46.224.181.82`)                 |
+| Database     | `beads_FC`                                                |
+| Host port    | `127.0.0.1:3307` (localhost only, SSH tunnel required)    |
+| SSH          | `ssh unfocused@46.224.181.82`                             |
+| Tunnel       | `ssh -fNL 3307:127.0.0.1:3307 unfocused@46.224.181.82`   |
+| BD_DSN       | `root:@tcp(127.0.0.1:3307)/beads_FC`                     |
 
-1. **Dolt SSH Tunnel**: Verify port 3307 is listening (SSH tunnel to Hetzner `unfocused@46.224.181.82`).
-   If not running, start it:
-   ```bash
-   ssh -fNL 3307:127.0.0.1:3307 unfocused@46.224.181.82
-   ```
+### Infrastructure Health Check (AUTOMATED — Session Start)
 
-2. **Beads/Dolt**: Run `bd dolt test`. If it fails, check the Dolt Docker container on Hetzner:
-   ```bash
-   ssh unfocused@46.224.181.82 "docker ps | grep dolt"
-   ```
-   If still failing, STOP and alert the user.
+A **SessionStart hook** (`.claude/hooks/preflight.sh`) runs automatically at the start of every agent session. It verifies:
 
-3. **Agent Mail**: Verify health at `https://getunfocused.app/health/liveness`. If unreachable or returning errors, STOP and alert the user.
+1. **Dolt SSH tunnel** (port 3307) — auto-starts if down, cascades to 3308/3309 if zombie ports
+2. **Beads connectivity** — verifies `bd list` works through the tunnel
+3. **Agent Mail** — verifies `https://getunfocused.app/health/liveness` returns alive
 
-4. **Beads readiness**: Run `bd ready` to load current task state.
+**If any check fails, the session BLOCKS (exit code 2).** The agent cannot proceed until all coordination services are online.
 
-**CRITICAL**: If Beads or Agent Mail are unreachable, **STOP and tell the user immediately.** Do NOT silently fall back to GitHub-only workflows. Use the startup scripts in `scripts/` or the preflight hook in `.claude/hooks/preflight.sh` to ensure proper initialization.
+**CRITICAL**: If Beads or Agent Mail are unreachable, **STOP and tell the user immediately.** Do NOT silently fall back to GitHub-only workflows.
 
 ### Autonomous Operation Rules
 
@@ -340,23 +341,70 @@ Parallel work that modifies the same file guarantees merge conflicts, even if th
 - [ ] No two Ready tasks touch the same file without a dependency chain
 - [ ] Critical shared files (e.g., `Field_Compass.ino`) identified and serialized first
 
+### Session State Management (Compaction Recovery)
+
+> **Applies ONLY in Worker mode (`/work` invoked). In Interactive mode, ignore this section entirely.**
+
+**Problem:** Context compaction erases the agent's working memory — what task it's on, which epic, what branch. This causes duplicate tasks, phantom closures, and scope drift.
+
+**Solution:** A persistent session state file (`.claude/agent-session.json`) that lives in the primary repo and is gitignored. The preflight hook reads it and outputs the state as a system reminder, which survives compaction.
+
+**Key files:**
+- `.claude/agent-session.json` — persisted session state (epic queue, current task, budget, PR history)
+- `.claude/hooks/session-state.sh` — management script with subcommands (init, read, update-task, check-budget, etc.)
+- `.claude/hooks/preflight.sh` Section 6 — outputs session state as system reminder
+
+**How it works:**
+1. `/work` initializes the session file via `session-state.sh init`
+2. Each task claim, close, and PR creation updates the file
+3. On compaction → new SessionStart → preflight reads the file → agent sees its state
+4. `session-state.sh init` refuses to overwrite an existing session (exit 1) → agent knows to recover instead of re-init
+5. Budget enforcement: `check-budget` returns exit 2 (HARD STOP) when exhausted
+6. Epic queue: `advance-epic` returns exit 2 when all epics processed
+
+### GitHub Board Sync (Label-Based)
+
+**Board status and priority are set via labels, not GraphQL commands.**
+
+A GitHub Action (`.github/workflows/sync-labels-to-board.yml`) watches for `board:*` and `priority:*` labels and syncs them to the Project V2 board fields. Agents NEVER run `gh project` commands.
+
+**How agents update the board:**
+```bash
+# Set status (REST — zero GraphQL cost from agent)
+gh issue edit 42 --add-label "board:in-progress"
+
+# Set priority (REST — zero GraphQL cost from agent)
+gh issue edit 42 --add-label "priority:P2"
+
+# Combine in one call
+gh issue edit 42 --add-label "board:ready,priority:P2"
+```
+
+**Available labels:**
+| Label | Board Column |
+|-------|-------------|
+| `board:backlog` | Backlog |
+| `board:todo` | Todo |
+| `board:ready` | Ready |
+| `board:in-progress` | In Progress |
+| `board:testing` | Testing |
+| `board:on-hold` | On Hold |
+| `board:done` | Done |
+| `priority:P0` through `priority:P3` | Priority field |
+
+Labels are mutually exclusive within their group — the Action auto-removes old labels.
+
 ### GitHub API Rate Limit Conservation (MANDATORY)
 
 GitHub's GraphQL API has a **5,000 point/hour limit per user** — shared across ALL agents and workflows. Exhausting it blocks every agent and CI pipeline.
 
 **Rules for all agents:**
 1. **Use `gh` CLI for issues** — these use the REST API (separate 5,000/hr budget, rarely exhausted).
-2. **Minimize `gh project` commands** — these use GraphQL. Query the board ONCE at session start, then work from Beads locally.
+2. **NEVER use `gh project` commands** — they consume GraphQL budget. Use labels instead (see Label-Based Board Sync above).
 3. **Never poll or loop** — no `watch`, no retries-in-a-loop on GitHub commands.
-4. **Batch board updates** — if you need to update multiple issues on the board, consider whether all are truly needed mid-session or can wait until session end.
-5. **Beads is your working state, GitHub is the sync target.** Use `bd` commands (zero API cost) for task tracking. Only touch GitHub for issue creation and final status sync.
-6. **Check rate limit before batch operations:**
-   ```bash
-   gh api rate_limit --jq '.resources.graphql.remaining'
-   # If < 500, defer non-essential board operations
-   ```
+4. **Beads is your working state, GitHub is the sync target.** Use `bd` commands (zero API cost) for task tracking. Only touch GitHub for issue creation, label sync, and closing issues.
 
-**What costs GraphQL points (AVOID unless necessary):**
+**What costs GraphQL points (NEVER use directly — the sync Action handles this):**
 - `gh project item-list` / `gh project item-edit` / `gh project item-add`
 - Any `gh api graphql` calls
 
@@ -364,6 +412,7 @@ GitHub's GraphQL API has a **5,000 point/hour limit per user** — shared across
 - `gh issue create/list/close/comment`
 - `gh pr create/list/view/merge`
 - `gh label create/list`
+- `gh issue edit --add-label` (this is how agents set board status/priority)
 
 ### Before Each Push Checklist
 
@@ -415,4 +464,4 @@ bd close <id> --reason "done"         # Complete task
 bd dep tree <epic-id>                 # View dependency tree
 ```
 
-**Note:** Status and Priority are managed through the GitHub Project board fields, not labels.
+**Note:** Status and Priority are set via `board:*` and `priority:*` labels (REST). The `sync-labels-to-board.yml` Action translates labels → board fields via GraphQL automatically. Agents NEVER run `gh project` commands directly.


### PR DESCRIPTION
## Summary
- **CLAUDE.md:** Added Dolt Server section, Session State Management for compaction recovery, Label-Based Board Sync documentation, updated infrastructure health check to reference automated preflight hook
- **auto-promote-ready.yml:** Complete rewrite — REST-only (zero GraphQL cost), checks `board:todo` label instead of querying project board items. Cron set to 4hr matching Unfocused.
- **GraphQL reduction:** Old auto-promote queried project items via GraphQL on every issue close + every 6hr cron. New version uses only REST API calls.

## Test plan
- [ ] Verify CLAUDE.md reads correctly — new sections don't break existing ones
- [ ] auto-promote fires on next issue close — uses `board:todo` label check
- [ ] Agents follow label-based board sync in next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)