### PR TITLE
chore(#137): per-session identity hooks (deploy #205 identity mechanism)

### DIFF
--- a/.claude/hooks/session-identity.py
+++ b/.claude/hooks/session-identity.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""session-identity.py — mechanical, collision-free per-session identity.
+
+Kills the shared-singleton collision: `agent_mail_identity` was one static
+string in `.claude/agent-session.json`, so every session read it and 10 became
+"RedCreek" on one mailbox, silently. Identity is instead keyed to the per-session
+UUID. See standards#190/#192, Mercury#12, memory reference_session_identity_from_uuid.
+
+STORE-AUTHORITATIVE (standards#192): the per-session file
+`.claude/sessions/<uuid>.json` is the source of truth. Identities are assigned
+once (by a human or, for a brand-new session, by derivation) and then **never
+silently changed**. This is a storage mechanism, not a renamer.
+
+Handle (all platform-independent; verified in Claude Desktop):
+  1. $CLAUDE_CODE_SESSION_ID           env var — present in Desktop AND CLI
+  2. UUID parsed from the scratchpad path / $PWD    (fallback)
+
+The invariant (standards#192 review): an already-recorded identity is NEVER
+overridden except by a deliberate, explicit `register --identity NAME`.
+  - `whoami`   : print the recorded identity verbatim; derive ONLY if no record.
+  - `register` : keep the recorded identity; derive ONLY if no record; set it
+                 only when `--identity` is given.
+  - A record that EXISTS but is UNREADABLE (corrupt/truncated) is a HARD ERROR,
+    never treated as "absent" — otherwise a crash mid-write would silently
+    re-derive over (e.g.) RedCreek. Absent -> derive; corrupt -> fail loud.
+
+Registry is one file per UUID (never a shared mutable singleton — that is the
+race we are fixing). Each session only ever writes its own file.
+
+Commands
+--------
+  whoami                     print this session's identity (default)
+  resolve                    JSON: {uuid, identity, recorded, source, entrypoint}
+  register [--identity NAME] SessionStart uses the no-arg form: it preserves an
+                             existing record and does NOT persist a fresh-derived
+                             name (deploy-safety, #195). `--identity` sets/changes.
+  migrate --from <root>      seed .claude/sessions/ from per-session scratchpad
+                             stores (agent-identity.json) — data-driven, never
+                             derives, never overrides a differing record (#195)
+  list                       consolidated index of all known sessions
+
+Exit codes
+----------
+  0  ok
+  1  no session UUID handle / invalid --identity (fail loud)
+  2  the session's record exists but is unreadable — refusing to override (fail loud)
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+_UUID_RE = re.compile(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+_MAX_IDENTITY_LEN = 64
+
+ADJ = ["Amber", "Azure", "Basalt", "Cobalt", "Crimson", "Dusk", "Ember", "Flint",
+       "Frost", "Glacier", "Granite", "Harbor", "Indigo", "Iron", "Jade", "Lunar",
+       "Maple", "Mesa", "Onyx", "Opal", "Pewter", "Quartz", "Raven", "Rust",
+       "Sable", "Slate", "Solar", "Storm", "Timber", "Umber", "Verde", "Willow"]
+NOUN = ["Basin", "Bluff", "Canyon", "Cedar", "Creek", "Delta", "Dune", "Falls",
+        "Fjord", "Glade", "Grove", "Hollow", "Knoll", "Ledge", "Marsh", "Moor",
+        "Otter", "Peak", "Pine", "Reef", "Ridge", "Shoal", "Spire", "Summit",
+        "Thicket", "Thorn", "Vale", "Warren", "Wharf", "Wren", "Yarrow", "Zephyr"]
+
+
+class CorruptRecord(Exception):
+    """The session's record file exists but could not be read/parsed."""
+
+
+def session_uuid():
+    """(uuid, source) or (None, None). Env var first, then path fallbacks."""
+    sid = (os.environ.get("CLAUDE_CODE_SESSION_ID") or "").strip()
+    if _UUID_RE.fullmatch(sid):
+        return sid, "env:CLAUDE_CODE_SESSION_ID"
+    for var in ("CLAUDE_SCRATCHPAD", "PWD", "OLDPWD"):
+        m = _UUID_RE.search(os.environ.get(var, ""))
+        if m:
+            return m.group(0), f"path:{var}"
+    return None, None
+
+
+def derive(uuid: str) -> str:
+    """UUID -> stable, AM-VALID adjective+noun placeholder — a LOCAL FALLBACK,
+    not a coordination identity.
+
+    Agent Mail is the authority for a session's identity: register with the name
+    OMITTED so AM assigns a valid, per-project-unique adjective+noun name, then
+    record THAT via `register --identity <AM-name>`. So derive() emits an
+    AM-valid *plain* adjective+noun with NO suffix — AM's register_agent rejects
+    suffixed names (e.g. `GlacierYarrow-63890f45`), which split-brained sessions
+    between their derived name and AM's assigned one (the recurring identity
+    fight, standards#204 / 2026-07-05). Uniqueness is AM's per-project dedup, not
+    a hash suffix; derive() is only a deterministic placeholder for the
+    AM-unreachable case (where you STOP and tell the user anyway). See CLAUDE-BASE
+    "Agent Mail identity" + memory reference_agent_mail_identity_authority.
+    """
+    h = hashlib.sha256(uuid.encode("utf-8")).digest()
+    return ADJ[h[0] % len(ADJ)] + NOUN[h[1] % len(NOUN)]
+
+
+def project_dir() -> Path:
+    p = os.environ.get("CLAUDE_PROJECT_DIR")
+    if p and Path(p).is_dir():
+        return Path(p)
+    try:
+        import subprocess
+        r = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                           capture_output=True, text=True, timeout=5)
+        if r.returncode == 0 and r.stdout.strip():
+            return Path(r.stdout.strip())
+    except Exception:
+        pass
+    return Path.cwd()
+
+
+def sessions_dir() -> Path:
+    """Where per-session identity records live.
+
+    Anchored to the git COMMON dir's parent (the primary repo root) so ALL
+    linked worktrees of a repo share ONE registry — identity is per-session-UUID,
+    not per-worktree, and a session must resolve to the same name whether it runs
+    in the primary clone or a worktree (standards#197). For the primary clone this
+    is the same path as project_dir(), so existing records are unaffected.
+    Falls back to project_dir() when not in a git repo.
+    """
+    base = project_dir()
+    try:
+        import subprocess
+        r = subprocess.run(
+            ["git", "-C", str(base), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True, text=True, timeout=5)
+        common = r.stdout.strip().replace("\\", "/")
+        if r.returncode == 0 and common:
+            return Path(common).parent / ".claude" / "sessions"
+    except Exception:
+        pass
+    return base / ".claude" / "sessions"
+
+
+def record_path(uuid: str) -> Path:
+    return sessions_dir() / f"{uuid}.json"
+
+
+def read_record(uuid: str):
+    """Return the record dict, or None if ABSENT.
+
+    Raises CorruptRecord if the file EXISTS but cannot be read/parsed — the
+    caller must NOT treat that as "absent" (that would re-derive over a real
+    identity). Distinguishing absent from corrupt is the core safety property.
+    """
+    f = record_path(uuid)
+    if not f.exists():
+        return None
+    try:
+        data = json.loads(f.read_text(encoding="utf-8"))
+    except Exception as e:  # unreadable / invalid JSON / permission / truncated
+        raise CorruptRecord(f"{f}: {e}") from e
+    if not isinstance(data, dict):
+        raise CorruptRecord(f"{f}: not a JSON object")
+    return data
+
+
+def _require_uuid():
+    uuid, source = session_uuid()
+    if not uuid:
+        print("NO_SESSION_UUID (no $CLAUDE_CODE_SESSION_ID or UUID in path)",
+              file=sys.stderr)
+        sys.exit(1)
+    return uuid, source
+
+
+def _read_or_die(uuid: str):
+    """read_record but turn CorruptRecord into a loud exit(2) — never override."""
+    try:
+        return read_record(uuid)
+    except CorruptRecord as e:
+        print(
+            f"BLOCKED: session identity record is unreadable — refusing to "
+            f"re-derive over it.\n  {e}\n  Fix or remove the file by hand once "
+            f"you know the correct identity; do NOT let it be silently renamed.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def _validate_identity(name: str) -> str:
+    n = (name or "").strip()
+    if not n:
+        print("BLOCKED: --identity must be non-empty / non-whitespace.", file=sys.stderr)
+        sys.exit(1)
+    if len(n) > _MAX_IDENTITY_LEN:
+        print(f"BLOCKED: --identity too long (>{_MAX_IDENTITY_LEN} chars).", file=sys.stderr)
+        sys.exit(1)
+    uuid, _ = session_uuid()
+    d = sessions_dir()
+    if d.is_dir():
+        for f in d.glob("*.json"):
+            try:
+                other = json.loads(f.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            if (isinstance(other, dict) and other.get("identity") == n
+                    and other.get("uuid") not in (None, uuid)):
+                print(f"⚠ identity '{n}' is already held by {other.get('uuid')} "
+                      f"({f.name}) — duplicate identities defeat the point.",
+                      file=sys.stderr)
+                break
+    return n
+
+
+def cmd_whoami() -> int:
+    uuid, _ = _require_uuid()
+    rec = _read_or_die(uuid)
+    print(rec["identity"] if (rec and rec.get("identity")) else derive(uuid))
+    return 0
+
+
+def cmd_resolve() -> int:
+    uuid, source = _require_uuid()
+    rec = _read_or_die(uuid)
+    identity = rec["identity"] if (rec and rec.get("identity")) else derive(uuid)
+    print(json.dumps({
+        "uuid": uuid,
+        "identity": identity,
+        "recorded": bool(rec and rec.get("identity")),
+        "source": source,
+        "entrypoint": os.environ.get("CLAUDE_CODE_ENTRYPOINT", "unknown"),
+    }))
+    return 0
+
+
+def _write_record(uuid: str, identity: str, source: str) -> None:
+    """Atomic pure write of KNOWN fields only (no read-merge -> no TOCTOU)."""
+    d = sessions_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    out = {
+        "uuid": uuid,
+        "identity": identity,
+        "entrypoint": os.environ.get("CLAUDE_CODE_ENTRYPOINT", "unknown"),
+        "source": source,
+        "cwd": str(Path.cwd()),
+        "updated": int(time.time()),
+    }
+    tmp = d / f".{uuid}.{os.getpid()}.tmp"   # PID-unique temp; final replace is atomic
+    tmp.write_text(json.dumps(out, indent=2), encoding="utf-8")
+    os.replace(tmp, record_path(uuid))
+
+
+def cmd_register(explicit_identity=None) -> int:
+    uuid, source = _require_uuid()
+    rec = _read_or_die(uuid)  # corrupt -> exit 2 BEFORE we could override
+    if explicit_identity is not None:
+        identity = _validate_identity(explicit_identity)    # deliberate set / migration
+        _write_record(uuid, identity, source)
+    elif rec and rec.get("identity"):
+        identity = rec["identity"]                          # KEEP existing — refresh metadata
+        _write_record(uuid, identity, source)
+    else:
+        # NO record + NO explicit identity: DO NOT persist a derived name — that
+        # would override an assigned-but-not-yet-seeded session (e.g. RedCreek
+        # before migration). Derivation is deterministic, so whoami recovers it
+        # on demand; a session claims a name explicitly with `register --identity`
+        # (or `migrate` seeds it). standards#195 deploy-safety.
+        print(derive(uuid))
+        return 0
+    print(identity)
+    return 0
+
+
+_STORE_FILES = ("agent-identity.json", "agent-mail-identity.json")
+_IDENTITY_KEYS = ("agent_name", "identity", "agent_mail_identity", "name", "mail_identity")
+
+
+def _extract_stored_identity(path: Path):
+    """Pull an assigned identity out of a workaround scratchpad store, or None."""
+    try:
+        d = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(d, dict) or d.get("do_not_use_identity"):
+        return None
+    for k in _IDENTITY_KEYS:
+        v = d.get(k)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
+
+def cmd_migrate(scratch_root=None) -> int:
+    """Seed .claude/sessions/<uuid>.json from per-session scratchpad stores.
+
+    Data-driven, never derives, never overrides: for each <uuid>/scratchpad/
+    agent-identity.json (or agent-mail-identity.json) that carries an assigned
+    identity, write the canonical record IF ABSENT. A canonical record that
+    already exists with a DIFFERENT identity is left alone (warned), never
+    clobbered — so re-running is idempotent and no one is renamed. standards#195.
+    """
+    if not scratch_root:
+        print("usage: session-identity.py migrate --from <scratchpad-root>", file=sys.stderr)
+        return 1
+    root = Path(scratch_root)
+    if not root.is_dir():
+        print(f"BLOCKED: --from is not a directory: {root}", file=sys.stderr)
+        return 1
+    seeded = ok = conflict = skipped = 0
+    for sess in sorted(root.iterdir()):
+        if not sess.is_dir() or not _UUID_RE.fullmatch(sess.name):
+            continue
+        uuid = sess.name
+        ident = None
+        for fn in _STORE_FILES:
+            ident = _extract_stored_identity(sess / "scratchpad" / fn)
+            if ident:
+                break
+        if not ident or len(ident) > _MAX_IDENTITY_LEN:
+            skipped += 1
+            continue
+        try:
+            existing = read_record(uuid)
+        except CorruptRecord:
+            print(f"  ! {uuid}: canonical record corrupt — skipping (fix by hand)", file=sys.stderr)
+            skipped += 1
+            continue
+        if existing and existing.get("identity"):
+            if existing["identity"] == ident:
+                ok += 1
+            else:
+                print(f"  ! {uuid}: canonical '{existing['identity']}' != store "
+                      f"'{ident}' — NOT overriding", file=sys.stderr)
+                conflict += 1
+            continue
+        _write_record(uuid, ident, f"migrated:{uuid[:8]}")
+        print(f"  + {ident:<22} {uuid}")
+        seeded += 1
+    print(f"\n  seeded={seeded} already-ok={ok} conflicts={conflict} skipped={skipped}",
+          file=sys.stderr)
+    return 0
+
+
+def cmd_list() -> int:
+    d = sessions_dir()
+    rows = []
+    if d.is_dir():
+        for f in sorted(d.glob("*.json")):
+            try:
+                rows.append(json.loads(f.read_text(encoding="utf-8")))
+            except Exception:
+                print(f"  ⚠ unreadable: {f.name}", file=sys.stderr)
+                continue
+    for r in rows:
+        if isinstance(r, dict):
+            print("  %-20s %-14s %s" % (
+                r.get("identity", "?"), r.get("entrypoint", "?"), r.get("uuid", "?")))
+    print(f"  ({len(rows)} session(s))")
+    return 0
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    cmd = args[0] if args else "whoami"
+    if cmd == "register":
+        explicit = None
+        if "--identity" in args:
+            i = args.index("--identity")
+            explicit = args[i + 1] if i + 1 < len(args) else ""
+        return cmd_register(explicit)
+    if cmd == "migrate":
+        frm = None
+        if "--from" in args:
+            i = args.index("--from")
+            frm = args[i + 1] if i + 1 < len(args) else None
+        return cmd_migrate(frm)
+    return {
+        "whoami": cmd_whoami,
+        "resolve": cmd_resolve,
+        "list": cmd_list,
+    }.get(cmd, cmd_whoami)()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/session-state.py
+++ b/.claude/hooks/session-state.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""session-state.py — compaction recovery state management.
+
+Canonical implementation per REPOCONFIG.md. Snapshots volatile session state
+that the post-compaction summary doesn't preserve reliably (claimed Citadel
+tasks, active worktree, Agent Mail identity, open PRs the session owns, last
+Tier 2 approval, agent investigation notes).
+
+Read at session start by preflight.sh §6, written by post-commit hook and by
+the agent on demand.
+
+Subcommands:
+    read                        Print human-readable summary to stdout.
+    write                       Snapshot live state into .claude/agent-session.json.
+    clear                       Remove the state file.
+    note <text>                 Append a freeform timestamped note.
+    identity <name>             Set agent_mail_identity. LEGACY — the
+                                authoritative identity now comes from
+                                session-identity.py (keyed to the session UUID);
+                                kept only for backward-compat during transition.
+    approval <action...>        Record a Tier 2 approval ("merge PR #N", etc.).
+
+State file schema v1 (.claude/agent-session.json):
+    {
+      "version": 1,
+      "project": "<name>",
+      "last_updated": "ISO8601 UTC",
+      "agent_mail_identity": "<window identity>",   # LEGACY — superseded by
+                                                     # session-identity.py; read
+                                                     # prefers that, this is fallback.
+      "active_worktree": {"path": "...", "branch": "..."},
+      "claimed_tasks": [{"task_id": "...", "external_issue_number": N,
+                         "claimed_at": "..."}],
+      "open_prs": [{"number": N, "title": "...", "branch": "..."}],
+      "last_tier2_approval": {"action": "...", "approved_at": "..."} | null,
+      "notes": "freeform"
+    }
+
+Failure mode: every subcommand is best-effort. If dw, gh, or git are
+missing, or any sub-query fails, degrade to whatever data IS available and
+write the file anyway. Never raises out of the hook context — the calling
+git operation must not fail because of state-snapshot trouble.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+
+
+def iso_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def project_root() -> Path:
+    """Resolve the project directory: git toplevel if available, else cwd.
+
+    Note: in a git worktree, --show-toplevel returns the worktree path, not
+    the main repo path. The state file lives in the worktree's .claude/
+    (each worktree gets its own snapshot, which is what we want for tracking
+    *that* worktree's branch and PR state).
+    """
+    env = os.environ.get("PROJECT_DIR")
+    if env:
+        return Path(env)
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True, capture_output=True, text=True, timeout=5,
+        ).stdout.strip()
+        if out:
+            return Path(out)
+    except Exception:
+        pass
+    return Path.cwd()
+
+
+def project_name(root: Path) -> str:
+    """Resolve the Citadel project name.
+
+    Precedence:
+      1. $DW_PROJECT env var (most reliable; user-set per session)
+      2. Parent-of-common-dir basename (correct in worktrees: --git-common-dir
+         points at the MAIN .git/, whose parent is the repo root)
+      3. git toplevel basename (correct in main checkout, wrong in worktrees)
+      4. cwd basename (final fallback)
+    """
+    env = os.environ.get("DW_PROJECT")
+    if env:
+        return env
+
+    # Worktree-aware: --git-common-dir resolves to the main .git/ even when
+    # invoked from inside a worktree. Its parent is the main repo root.
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            check=True, capture_output=True, text=True, timeout=5,
+            cwd=str(root),
+        ).stdout.strip()
+        if out:
+            common = Path(out)
+            # If the git common dir is named ".git", its parent is the repo
+            # root. (Worktrees keep .git as a file pointing at the main one.)
+            if common.name == ".git":
+                return common.parent.name
+            # Bare repo or unusual layout — fall through.
+    except Exception:
+        pass
+
+    if root.name:
+        return root.name
+    return "unknown"
+
+
+def state_file(root: Path) -> Path:
+    return root / ".claude" / "agent-session.json"
+
+
+def load_state(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def save_state(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data["last_updated"] = iso_now()
+    path.write_text(
+        json.dumps(data, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def run_capture(cmd: list[str], timeout: int = 10) -> str | None:
+    """Run a command, return stdout on success, None on any failure."""
+    try:
+        res = subprocess.run(
+            cmd, check=True, capture_output=True, text=True, timeout=timeout,
+        )
+        return res.stdout
+    except Exception:
+        return None
+
+
+def query_claimed_tasks(project: str) -> list[dict]:
+    """`dw --project <p> list --status in_progress --json` -> normalized list."""
+    if project == "unknown":
+        return []
+    raw = run_capture(["dw", "--json", "--project", project, "list",
+                       "--status", "in_progress"])
+    if not raw:
+        return []
+    try:
+        items = json.loads(raw)
+    except Exception:
+        return []
+    out = []
+    for t in items if isinstance(items, list) else []:
+        out.append({
+            "task_id": t.get("short_id") or t.get("id") or "",
+            "title": t.get("title", ""),
+            "external_issue_number": t.get("external_issue_number") or 0,
+            "claimed_at": (t.get("claimed_at") or t.get("updated_at")
+                           or t.get("created_at") or ""),
+        })
+    return out
+
+
+def query_open_prs() -> list[dict]:
+    """`gh pr list --author @me --state open --json ...` -> normalized list."""
+    raw = run_capture(["gh", "pr", "list", "--author", "@me",
+                       "--state", "open",
+                       "--json", "number,title,headRefName"])
+    if not raw:
+        return []
+    try:
+        items = json.loads(raw)
+    except Exception:
+        return []
+    out = []
+    for p in items if isinstance(items, list) else []:
+        out.append({
+            "number": p.get("number"),
+            "title": p.get("title", ""),
+            "branch": p.get("headRefName", ""),
+        })
+    return out
+
+
+def query_worktree(root: Path) -> dict:
+    branch = run_capture(["git", "-C", str(root), "rev-parse",
+                          "--abbrev-ref", "HEAD"])
+    return {
+        "path": str(root),
+        "branch": branch.strip() if branch else "",
+    }
+
+
+def session_identity_name() -> str:
+    """Authoritative per-session identity from the sibling session-identity.py
+    hook (keyed to the session UUID; standards#190/#192/#197). SUPERSEDES the
+    legacy `agent_mail_identity` singleton — that field lived in the shared
+    agent-session.json, so every concurrent session read the same name (the
+    "10 concurrent RedCreeks" collision). Best-effort: returns "" if the sibling
+    hook is absent (repo not yet fanned out) or errors, so cmd_read falls back
+    to the stored field during the transition.
+    """
+    script = Path(__file__).resolve().parent / "session-identity.py"
+    if not script.exists():
+        return ""
+    for py in ("python3", "python"):
+        out = run_capture([py, str(script), "whoami"], timeout=5)
+        if out is None:
+            continue  # nonzero exit (no UUID / corrupt record) or py absent
+        line = out.strip().splitlines()[-1].strip() if out.strip() else ""
+        if line and not line.startswith(("NO_SESSION", "BLOCKED", "usage")):
+            return line
+    return ""
+
+
+# ─── subcommands ─────────────────────────────────────────────────────────
+
+def cmd_read(args: list[str]) -> int:
+    root = project_root()
+    path = state_file(root)
+    if not path.exists():
+        # No state file = nothing to surface. preflight §6 treats empty
+        # stdout as "no active session" — correct for first-run.
+        return 0
+    data = load_state(path)
+    if not data:
+        return 0
+
+    print(f"Last snapshot: {data.get('last_updated', 'unknown')}")
+    # Authoritative per-session identity (session-identity.py, keyed to UUID);
+    # fall back to the legacy singleton only where that hook isn't deployed yet.
+    identity = session_identity_name() or (data.get("agent_mail_identity") or "")
+    if identity:
+        print(f"Session identity: {identity}")
+    wt = data.get("active_worktree") or {}
+    if wt.get("path"):
+        print(f"Active worktree: {wt.get('branch', '?')}  ({wt['path']})")
+    tasks = data.get("claimed_tasks") or []
+    if tasks:
+        print(f"Claimed Citadel tasks ({len(tasks)}):")
+        for t in tasks:
+            issue = t.get("external_issue_number") or 0
+            issue_str = f"#{issue}" if issue else "no-issue"
+            print(f"  - {t.get('task_id', '?')} ({issue_str}) "
+                  f"claimed {t.get('claimed_at', '?')}")
+    prs = data.get("open_prs") or []
+    if prs:
+        print(f"Open PRs ({len(prs)}):")
+        for p in prs:
+            print(f"  - #{p.get('number', '?')} {p.get('title', '')}  "
+                  f"({p.get('branch', '')})")
+    approval = data.get("last_tier2_approval")
+    if approval and approval.get("action"):
+        print(f"Last Tier 2 approval: {approval['action']}  "
+              f"({approval.get('approved_at', '?')})")
+    notes = data.get("notes") or ""
+    if notes:
+        print("Notes:")
+        for line in notes.splitlines():
+            print(f"  {line}")
+    return 0
+
+
+def cmd_write(args: list[str]) -> int:
+    root = project_root()
+    path = state_file(root)
+    name = project_name(root)
+
+    prior = load_state(path)
+
+    data = {
+        "version": SCHEMA_VERSION,
+        "project": name,
+        "last_updated": iso_now(),
+        "agent_mail_identity": prior.get("agent_mail_identity", ""),
+        "active_worktree": query_worktree(root),
+        "claimed_tasks": query_claimed_tasks(name),
+        "open_prs": query_open_prs(),
+        "last_tier2_approval": prior.get("last_tier2_approval"),
+        "notes": prior.get("notes", ""),
+    }
+    save_state(path, data)
+    print(f"Wrote {path}")
+    return 0
+
+
+def cmd_clear(args: list[str]) -> int:
+    path = state_file(project_root())
+    if path.exists():
+        path.unlink()
+        print(f"Cleared {path}")
+    return 0
+
+
+def cmd_note(args: list[str]) -> int:
+    if not args:
+        print("Usage: session-state.py note <text>", file=sys.stderr)
+        return 1
+    root = project_root()
+    path = state_file(root)
+    text = " ".join(args)
+    now = iso_now()
+    data = load_state(path)
+    if not data:
+        data = {
+            "version": SCHEMA_VERSION,
+            "project": project_name(root),
+            "agent_mail_identity": "",
+            "active_worktree": {},
+            "claimed_tasks": [],
+            "open_prs": [],
+            "last_tier2_approval": None,
+            "notes": "",
+        }
+    existing = data.get("notes") or ""
+    entry = f"{now}: {text}"
+    data["notes"] = f"{existing}\n{entry}" if existing else entry
+    save_state(path, data)
+    print("Note added")
+    return 0
+
+
+def cmd_identity(args: list[str]) -> int:
+    if not args:
+        print("Usage: session-state.py identity <name>", file=sys.stderr)
+        return 1
+    root = project_root()
+    path = state_file(root)
+    data = load_state(path)
+    if not data:
+        data = {
+            "version": SCHEMA_VERSION,
+            "project": project_name(root),
+            "active_worktree": {},
+            "claimed_tasks": [],
+            "open_prs": [],
+            "last_tier2_approval": None,
+            "notes": "",
+        }
+    data["agent_mail_identity"] = args[0]
+    save_state(path, data)
+    print(f"Identity set: {args[0]}")
+    return 0
+
+
+def cmd_approval(args: list[str]) -> int:
+    if not args:
+        print("Usage: session-state.py approval <action description>",
+              file=sys.stderr)
+        return 1
+    root = project_root()
+    path = state_file(root)
+    action = " ".join(args)
+    now = iso_now()
+    data = load_state(path)
+    if not data:
+        data = {
+            "version": SCHEMA_VERSION,
+            "project": project_name(root),
+            "agent_mail_identity": "",
+            "active_worktree": {},
+            "claimed_tasks": [],
+            "open_prs": [],
+            "notes": "",
+        }
+    data["last_tier2_approval"] = {"action": action, "approved_at": now}
+    save_state(path, data)
+    print(f"Approval recorded: {action}")
+    return 0
+
+
+COMMANDS = {
+    "read": cmd_read,
+    "write": cmd_write,
+    "clear": cmd_clear,
+    "note": cmd_note,
+    "identity": cmd_identity,
+    "approval": cmd_approval,
+}
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    if not argv:
+        # Default subcommand = read (so preflight can call without args).
+        return cmd_read([])
+    sub = argv[0]
+    rest = argv[1:]
+    if sub not in COMMANDS:
+        print(f"Usage: {sys.argv[0]} {{{'|'.join(COMMANDS)}}}",
+              file=sys.stderr)
+        return 1
+    try:
+        return COMMANDS[sub](rest)
+    except Exception as e:
+        # Defensive: never raise out of a hook context.
+        print(f"session-state.py {sub}: {e}", file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/preflight.sh\"",
             "timeout": 30000
+          },
+          {
+            "type": "command",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-identity.py\" register",
+            "timeout": 10000
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ desktop.ini
 /issues.json
 /project-items.json
 PHASE*.md
+
+# Per-session identity records (runtime, local)
+.claude/sessions/


### PR DESCRIPTION
Fan-out/refresh of the canonical identity mechanism (standards PRs 199/200/205): session-identity.py (AM-valid plain adjective+noun derive, git-common-dir anchored) + session-state.py (sources sibling) + gitignore .claude/sessions/ + SessionStart register.

Closes #137